### PR TITLE
Introduces tRPC response caching

### DIFF
--- a/apps/web/src/utils/trpc.ts
+++ b/apps/web/src/utils/trpc.ts
@@ -8,6 +8,14 @@ export const trpc = createTRPCNext<AppRouter>({
       links: [
         httpBatchLink({
           url: '/api/trpc/',
+          headers() {
+            if (!ctx?.req?.headers) {
+              return {};
+            }
+
+            const { connection: _connection, ...headers } = ctx.req.headers;
+            return headers;
+          },
         }),
       ],
     };


### PR DESCRIPTION
Cache all tRPC queries (GET requests) on Vercel's edge network (stale after 1 day) to speed up response times and lower trips to the database.